### PR TITLE
Workaround terrible bug in grails 2.4.4 that fails to render lists to JSON

### DIFF
--- a/application.properties
+++ b/application.properties
@@ -1,4 +1,4 @@
 #Grails Metadata file
-#Sun Sep 07 18:01:22 PDT 2014
-app.grails.version=2.4.3
+#Fri Jan 30 13:44:29 PST 2015
+app.grails.version=2.4.4
 app.name=swaggydoc

--- a/grails-app/controllers/com/github/rahulsom/swaggydoc/ApiController.groovy
+++ b/grails-app/controllers/com/github/rahulsom/swaggydoc/ApiController.groovy
@@ -40,7 +40,7 @@ class ApiController {
         render([
                 apiVersion    : config.apiVersion ?: grailsApplication.metadata['app.version'],
                 swaggerVersion: '1.2',
-                apis          : apis,
+                apis          : apis?.toArray(),
                 info          : infoObject
         ] as JSON)
     }
@@ -150,16 +150,16 @@ class ApiController {
 
         def groupedApis = apis.
                 groupBy { Map it -> it.path }.
-                collect { p, a -> [path: p, operations: (a as List<Map>).collect { it.operations }.flatten().unique()] }
+                collect { p, a -> [path: p, operations: (a as List<Map>).collect { it.operations }.flatten().unique()?.toArray()] }
 
         render([
                 apiVersion    : config.apiVersion ?: grailsApplication.metadata['app.version'],
                 swaggerVersion: '1.2',
                 basePath      : api.basePath() ?: absoluteBasePath,
                 resourcePath  : resourcePath - basePath,
-                produces      : api.produces()?.tokenize(',') ?: ['application/json', 'application/xml', 'text/html'],
-                consumes      : api.consumes()?.tokenize(',') ?: ['application/json', 'application/xml', 'application/x-www-form-urlencoded'],
-                apis          : groupedApis,
+                produces      : (api.produces()?.tokenize(',') ?: ['application/json', 'application/xml', 'text/html']).toArray(),
+                consumes      : (api.consumes()?.tokenize(',') ?: ['application/json', 'application/xml', 'application/x-www-form-urlencoded']).toArray(),
+                apis          : groupedApis?.toArray(),
                 models        : models,
 
         ] as JSON)
@@ -182,7 +182,7 @@ class ApiController {
 
             def modelDescription = [
                     id        : model.simpleName,
-                    required  : required,
+                    required  : required?.toArray(),
                     properties: props.collectEntries { Field f -> [f.name, getTypeDescriptor(f, grailsDomainClass)] }
             ]
 
@@ -380,11 +380,11 @@ class ApiController {
                                 method          : httpMethod,
                                 summary         : summary,
                                 nickname        : inferredNickname,
-                                parameters      : parameters,
+                                parameters      : parameters?.toArray(),
                                 type            : domainName,
-                                responseMessages: responseMessages
+                                responseMessages: responseMessages?.toArray()
                         ]
-                ]
+                ].toArray()
         ]
     }
 
@@ -413,11 +413,11 @@ class ApiController {
                                 summary         : apiOperation.value(),
                                 notes           : apiOperation.notes(),
                                 nickname        : apiOperation.nickname() ?: inferredNickname,
-                                parameters      : parameters,
+                                parameters      : parameters?.toArray(),
                                 type            : apiOperation.response() == Void ? 'void' : apiOperation.response().simpleName,
                                 responseMessages: apiResponses?.value()?.collect { ApiResponse apiResponse ->
                                     [code: apiResponse.code(), message: apiResponse.message()]
-                                }
+                                }?.toArray()
                         ]
                 ]
         ]


### PR DESCRIPTION
See [JsonCollectionRenderer fails rendering response for Rest Controllers in Grails 2.4.4](https://jira.grails.org/browse/GRAILS-11892) for details.

I don't know if you want to pull this in or not, it's an ugly hack. But it has the virtue of making this plugin work on grails 2.4.4 (the current release version does not, at least not for me.) Presumably once this bug is fixed this can be reverted.
