### PR TITLE
Declared "marshallers" dependency as test-only, so it doesn't propagate

### DIFF
--- a/grails-app/conf/BuildConfig.groovy
+++ b/grails-app/conf/BuildConfig.groovy
@@ -54,7 +54,7 @@ grails.project.dependency.resolution = {
         build (":tomcat:7.0.55") {
             export = false
         }
-        compile (":marshallers:0.6")
+        test (":marshallers:0.6")
 
     }
 }


### PR DESCRIPTION
This was an "oops" on my part. The intention was not to propagate "marshallers" as a dependency, only to support introspection into marshallers configuration if it was in use. Code is correct, but dependency wasn't declared right, so current version of swaggydoc is propagating the dependency needlessly.

Please pull and release.