### PR TITLE
Reversed the isAssignableFrom for Lists and Sets

### DIFF
--- a/grails-app/services/com/github/rahulsom/swaggydoc/SwaggyDataService.groovy
+++ b/grails-app/services/com/github/rahulsom/swaggydoc/SwaggyDataService.groovy
@@ -489,8 +489,9 @@ class SwaggyDataService {
 
             models[model.simpleName] = modelDescription
             props.each { f ->
+                log.debug("Processing field ${f} of type ${f.type}")
                 if (!models.containsKey(f.type.simpleName) && !m.contains(f.type) && !knownTypes.contains(f.type)) {
-                    if (f.type.isAssignableFrom(List) || f.type.isAssignableFrom(Set)) {
+                    if (List.isAssignableFrom(f.type) || Set.isAssignableFrom(f.type)) {
                         if (f instanceof GrailsDomainClassProperty) {
                             def genericType = domainClass?.associationMap?.getAt(f.name)
                             if (genericType) {


### PR DESCRIPTION
In order to check if the field is a List or a Set, as:

    assert Object.isAssignableFrom(List)
    assert !List.isAssignableFrom(Object)

This addresses the cases where a field is declared as `Object` or `def`