### PR TITLE
Add instruction to browse to /api in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,3 +172,5 @@ class DemoController extends RestfulController {
     }
 }
 ```
+
+After this, just browse to `/api`.


### PR DESCRIPTION
I took me to find how to see Swagger UI after setting the annotations in controller. Add this information at the README end to help.