### PR TITLE
Added support for Swagger annotation '@ApiModelProperty' value

### DIFF
--- a/grails-app/domain/com/github/rahulsom/swaggydoc/test/Domain.groovy
+++ b/grails-app/domain/com/github/rahulsom/swaggydoc/test/Domain.groovy
@@ -1,8 +1,12 @@
 package com.github.rahulsom.swaggydoc.test
 
+import com.wordnik.swagger.annotations.ApiModelProperty
+
 class Domain {
 
+    @ApiModelProperty(value = "Name of the domain")
     String name
+    @ApiModelProperty(value = "Description of the domain")
     String description
     String unmentionable
 

--- a/grails-app/services/com/github/rahulsom/swaggydoc/SwaggyDataService.groovy
+++ b/grails-app/services/com/github/rahulsom/swaggydoc/SwaggyDataService.groovy
@@ -51,7 +51,7 @@ class SwaggyDataService {
                         },
                 ], [], true)
             },
-            show: { String domainName ->
+            show : { String domainName ->
                 new DefaultAction(SwaggyShow, domainName, [new Parameter('id', 'Identifier to look for', 'path', 'string', true)],
                         [
                                 new ResponseMessage(BAD_REQUEST, 'Bad Request'),
@@ -59,7 +59,7 @@ class SwaggyDataService {
                         ]
                 )
             },
-            save: { String domainName ->
+            save : { String domainName ->
                 new DefaultAction(SwaggySave, domainName, [new Parameter('body', "Description of ${domainName}", 'body', domainName, true)],
                         [
                                 new ResponseMessage(CREATED, "New ${domainName} created"),
@@ -656,6 +656,8 @@ class SwaggyDataService {
     private Field getTypeDescriptor(def f, GrailsDomainClass gdc) {
 
         String fieldName = f.name
+        def declaredField = gdc?.clazz?.getDeclaredFields()?.find { it.name == fieldName }
+        def apiModelProperty = declaredField ? findAnnotation(ApiModelProperty, declaredField) : null
         def constrainedProperty = gdc?.constraints?.getAt(fieldName) as ConstrainedProperty
         Class type = f.type
         Field field
@@ -684,6 +686,7 @@ class SwaggyDataService {
         } else {
             field = new RefField(type.simpleName)
         }
+        field.description = apiModelProperty?.value()
         return field
     }
 

--- a/src/groovy/com/github/rahulsom/swaggydoc/Types.groovy
+++ b/src/groovy/com/github/rahulsom/swaggydoc/Types.groovy
@@ -26,7 +26,9 @@ class TypeItem extends Item {
 
 /* Field classes */
 
-class Field {}
+class Field {
+    String description
+}
 
 class BooleanField extends Field {
     def getType() { 'boolean' }

--- a/test/integration/com/github/rahulsom/swaggydoc/ApiControllerSpec.groovy
+++ b/test/integration/com/github/rahulsom/swaggydoc/ApiControllerSpec.groovy
@@ -121,9 +121,11 @@ class ApiControllerSpec extends Specification {
 
         assert domainProps.description
         assert domainProps.description.type == 'string'
+        assert domainProps.description.description == 'Description of the domain'
 
         assert domainProps.name
         assert domainProps.name.type == 'string'
+        assert domainProps.name.description == 'Name of the domain'
 
         assert domainProps.version
         assert domainProps.version.type == 'integer'


### PR DESCRIPTION
This allows documentation of domain's properties. There is no need to use '@ApiModel' on the domain class.